### PR TITLE
🐛 Specified deployer address and swapped indexer for algod

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -19,9 +19,9 @@ const appClient = new HelloWorldClient(
     resolveBy: 'creatorAndName',
     findExistingUsing: indexer,
     sender: deployer,
-    creatorAddress: deployer,
+    creatorAddress: deployer.addr,
   },
-  indexer,
+  algod,
 )
 
 await appClient.create.createApplication({});


### PR DESCRIPTION
## Fix the Bug Submission Pull Request

**What was the bug?**

`creatorAddress` is of type string but Deployer is of type account. 
The second argument to `appClient` is algod not indexer.



**How did you fix the bug?**
I changed `creatorAddress:deployer` -> `creatorAddress: deployer.addr`
I swapped `indexer` for `algod`

**Console Screenshot:**
<img width="1617" alt="Screen Shot 2024-03-19 at 5 01 33 PM" src="https://github.com/algorand-coding-challenges/challenge-3/assets/26069470/b6f234bb-b612-4f49-8689-f11807de7e0a">


<!-- Attach a screenshot of your console showing the result specified in the README. -->