### PR TITLE
Challenge 3 Solved

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "cSpell.words": [
+        "Algodev",
+        "algokit",
+        "Algorand",
+        "localnet"
+    ]
+}

--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -19,9 +19,9 @@ const appClient = new HelloWorldClient(
     resolveBy: 'creatorAndName',
     findExistingUsing: indexer,
     sender: deployer,
-    creatorAddress: deployer,
+    creatorAddress: deployer.addr,
   },
-  indexer,
+  algod,
 )
 
 await appClient.create.createApplication({});


### PR DESCRIPTION
## Fix the Bug Submission Pull Request

**What was the bug?**
while, creating the new instance of the `HelloWorldClient` app client, the creator address `creatorAddress` was not set to the deployer's address as a string in `index.js`. Here we can say that the deployer is our localnet dispenser which means it is an Algorand account and have more property.

While referring to the Algorand Developers Docs, creator's address is must linked / redirected to deployer's address.


**How did you fix the bug?**
referred same algorand developers docs, by changing the 
` creatorAddress: deployer`  to `creatorAddress: deployer.addr` 
so that the address is specified correctly.
also the `indexer` needs to be changed to `algod` for creating the new instance of the `HelloWorldClient` app client.


**Console Screenshot:**
![image](https://github.com/algorand-coding-challenges/challenge-3/assets/79416752/6162602a-bbde-4500-a5c8-a44c2cb42bba)
