### PR TITLE
fix: creatorAddress pointing to deployer account instance, client pointing to indexer client not algod client

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -19,14 +19,14 @@ const appClient = new HelloWorldClient(
     resolveBy: 'creatorAndName',
     findExistingUsing: indexer,
     sender: deployer,
-    creatorAddress: deployer,
+    creatorAddress: deployer.addr,
   },
-  indexer,
+  algod,
 )
 
 await appClient.create.createApplication({});
 
 // TODO: change YOUR_NAME to your name or nickname
-const result = await appClient.helloWorld({name: "YOUR_NAME"}, {sendParams: {suppressLog: true}})
+const result = await appClient.helloWorld({name: "akomar812"}, {sendParams: {suppressLog: true}})
 
 console.log(result.return)


### PR DESCRIPTION
## Fix the Bug Submission Pull Request

**What was the bug?**

There were two bugs, both in the interface for the smart contract client:

1. The client's creatorAddress was pointing to the instance of the deployer's account object where it expected an address string
2. The client was pointed to the program's indexer client where it was expecting an algod client

**How did you fix the bug?**

1. Use the address property provided by the deployer account instance (change `deployer` to `deployer.addr`)
2. Use algod instance where algod client was expected, instead of indexer (change `indexer` to `algod` in second param of smart contract client interface

**Console Screenshot:**

<img width="1000" alt="Screenshot 2024-03-19 at 6 41 46 PM" src="https://github.com/algorand-coding-challenges/challenge-3/assets/5781627/d4cba76a-1159-4443-84bf-d33e5ca28d38">
