### PR TITLE
Fix HelloWorldClient init

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -6,27 +6,19 @@ const indexer = algokit.getAlgoIndexerClient()
 const kmd = algokit.getAlgoKmdClient()
 const deployer = await algokit.getLocalNetDispenserAccount(algod, kmd)
 
-/*
-FIX THE BUG:
-
-The following code will create an instance of the HelloWorldClient and call the helloWorld function.
-There are 2 bugs in the below code. Find and fix them.
-
-Hint: Read the Typed clients section in the documentation: https://developer.algorand.org/docs/get-details/algokit/features/generate/?from_query=algokit%20utils#1-typed-clients
-*/
 const appClient = new HelloWorldClient(
   {
     resolveBy: 'creatorAndName',
     findExistingUsing: indexer,
     sender: deployer,
-    creatorAddress: deployer,
+    creatorAddress: deployer.addr,
   },
-  indexer,
+  algod,
 )
 
 await appClient.create.createApplication({});
 
 // TODO: change YOUR_NAME to your name or nickname
-const result = await appClient.helloWorld({name: "YOUR_NAME"}, {sendParams: {suppressLog: true}})
+const result = await appClient.helloWorld({ name: "algorambo" }, { sendParams: { suppressLog: true } })
 
 console.log(result.return)


### PR DESCRIPTION
## Fix the Bug Submission Pull Request

**What was the bug?**

There were two bugs, both in the `/challenge/index.ts` file and both related to the instantiation of the `HelloWorldClient` class:
1. The `creatorAddress`  property expects a string address, but instead an `Account` object was given to it.
2. The `HelloWorldClient` needs an `algod` client instance to be able to interact with the deployed smart contract, however an `indexer` was passed in its place.

**How did you fix the bug?**

1. Instead of giving an `Account` object, its address was passed to the `creatorAddress` property:
```typescript
creatorAddress: deployer.addr,
```
2. Instead of using the `indexer` object, the `algod` client was passed as the second parameter of the `HelloWorldClient` object.

**Console Screenshot:**

<img width="784" alt="image" src="https://github.com/algorand-coding-challenges/challenge-3/assets/162426140/cce0c8ba-b4ab-4f4d-b26d-24f79bcedebc">
