### PR TITLE
Fix instantiation of HelloWorldClient

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -19,14 +19,13 @@ const appClient = new HelloWorldClient(
     resolveBy: 'creatorAndName',
     findExistingUsing: indexer,
     sender: deployer,
-    creatorAddress: deployer,
+    creatorAddress: deployer.addr,
   },
-  indexer,
+  algod,
 )
 
 await appClient.create.createApplication({});
 
-// TODO: change YOUR_NAME to your name or nickname
-const result = await appClient.helloWorld({name: "YOUR_NAME"}, {sendParams: {suppressLog: true}})
+const result = await appClient.helloWorld({name: "Drahlous"}, {sendParams: {suppressLog: true}})
 
 console.log(result.return)


### PR DESCRIPTION
## Fix the Bug Submission Pull Request

**What was the bug?**

There were two bugs in the instantiation of the HelloWorldClient object:
1. The `creatorAddress` was assigned to the entire deployer account instead of just the deployer's address.
2. The `HelloWorldClient` takes an `algod` instance as its second argument, but an `indexer` was being incorrectly supplied in that argument.

**How did you fix the bug?**

Two changes were required to fix the bug:
1. Initialize the `creatorAddress` field with they deployer's address by accessing the `addr` property : `deployer.addr`
2. Supply the `algod` object instead of the `indexer` object as the second argument in the `HelloWorldClient` constructor.

**Console Screenshot:**
![image](https://github.com/algorand-coding-challenges/challenge-3/assets/28247765/fdc0e8a3-d207-4685-a9dc-e0cf5e56bba8)

