### PR TITLE
fix params passed to the app client

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -19,14 +19,14 @@ const appClient = new HelloWorldClient(
     resolveBy: 'creatorAndName',
     findExistingUsing: indexer,
     sender: deployer,
-    creatorAddress: deployer,
+    creatorAddress: deployer.addr,
   },
-  indexer,
+  algod,
 )
 
 await appClient.create.createApplication({});
 
 // TODO: change YOUR_NAME to your name or nickname
-const result = await appClient.helloWorld({name: "YOUR_NAME"}, {sendParams: {suppressLog: true}})
+const result = await appClient.helloWorld({name: "willi.am"}, {sendParams: {suppressLog: true}})
 
 console.log(result.return)


### PR DESCRIPTION
## Fix the Bug Submission Pull Request

**What was the bug?**

1. The generated client in teal script expects the address of the creator account which happens to be a string. This is part of the app details used to identify the app to be deployed. In python, this may have been correct since the client would expected the creator's account object (as one of the required parameters) which is typed as `Account`.

2. Apart from the app details captured as the first parameter of the app client, the second parameter that is required is the `AlgodClient`. What was however passed was the indexer which also happens to be part of the first parameter i.e. the app details.

**How did you fix the bug?**

1. The deployer object has a property named `addr` that holds the address string of the account object. The solution was to simply pass the `addr` property of the `deployer` object as the `creatorAddress` parameter.

2. The second fix was to remove the `indexer` object as the second parameter and instead pass the `algod` (`AlgoClient`) object.

**Console Screenshot:**

![image](https://github.com/algorand-coding-challenges/challenge-3/assets/40172652/5dc7d7b2-3f6c-474d-b579-7de1b5f07e60)