### PR TITLE
Fix Client initialisation bug

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -19,9 +19,9 @@ const appClient = new HelloWorldClient(
     resolveBy: 'creatorAndName',
     findExistingUsing: indexer,
     sender: deployer,
-    creatorAddress: deployer,
+    creatorAddress: deployer.addr,
   },
-  indexer,
+  algod,
 )
 
 await appClient.create.createApplication({});


### PR DESCRIPTION
## Fix the Bug Submission Pull Request

**What was the bug?**
There were two bugs:
1. When creating a new instance of the app client, the entire deployer account object was passed to the creatorAddress field of the first argument, instead of passing the deployer account's address.
2. The indexer object was passed as a second argument to the client constructur instead of the algod client. 

**How did you fix the bug?**
To fix the aforementioned bugs, I passed the deployer's address to the creatorAddress field instead of passing the entire deployer account object. Also, I passed the algod client object as the second argument to the constructor instead of the indexer.

**Console Screenshot:**
![image](https://github.com/algorand-coding-challenges/challenge-3/assets/68940073/2e57cd44-b75b-4712-91f9-b6b90f382cb3)