### PR TITLE
fix: creator address, appclient

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -1,10 +1,12 @@
-import { HelloWorldClient } from './contracts/clients/helloWorldClient'
-import * as algokit from '@algorandfoundation/algokit-utils'
+import { HelloWorldClient } from "./contracts/clients/helloWorldClient";
+import * as algokit from "@algorandfoundation/algokit-utils";
 
-const algod = algokit.getAlgoClient()
-const indexer = algokit.getAlgoIndexerClient()
-const kmd = algokit.getAlgoKmdClient()
-const deployer = await algokit.getLocalNetDispenserAccount(algod, kmd)
+const algod = algokit.getAlgoClient();
+const indexer = algokit.getAlgoIndexerClient();
+const kmd = algokit.getAlgoKmdClient();
+const deployer = await algokit.getLocalNetDispenserAccount(algod, kmd);
+
+const nickname: string = "LeslieOA";
 
 /*
 FIX THE BUG:
@@ -16,17 +18,19 @@ Hint: Read the Typed clients section in the documentation: https://developer.alg
 */
 const appClient = new HelloWorldClient(
   {
-    resolveBy: 'creatorAndName',
+    resolveBy: "creatorAndName",
     findExistingUsing: indexer,
     sender: deployer,
-    creatorAddress: deployer,
+    creatorAddress: deployer.addr,
   },
-  indexer,
-)
+  algod
+);
 
 await appClient.create.createApplication({});
 
-// TODO: change YOUR_NAME to your name or nickname
-const result = await appClient.helloWorld({name: "YOUR_NAME"}, {sendParams: {suppressLog: true}})
+const result = await appClient.helloWorld(
+  { name: nickname },
+  { sendParams: { suppressLog: true } }
+);
 
-console.log(result.return)
+console.log(result.return);


### PR DESCRIPTION
## Fix the Bug Submission Pull Request

**What was the bug?**

1. Constructor was incorrectly being called with `indexer` (rather than `algod`)
2. `creatorAddress` was set to the `deployer` rather than the deployers address

**How did you fix the bug?**

1. Replaced `indexer` with `algod` in the constructor
2. Set `creatorAddress` to the deployers address `deployer.addr`

**Console Screenshot:**

<img width="1728" alt="Screenshot 2024-03-22 at 04 40 27" src="https://github.com/algorand-coding-challenges/challenge-3/assets/145453/611b1cad-d935-44c5-8558-90a085e02e1c">

✌🏾